### PR TITLE
fix assembly reference

### DIFF
--- a/Leopotam.Ecs.asmref
+++ b/Leopotam.Ecs.asmref
@@ -1,3 +1,3 @@
 {
-    "reference": "GUID:656c2c43d3cfe4855bd40e058874b0be"
+    "reference": "GUID:e59bf9fc7d5a44b18a819a92edd46163"
 }

--- a/Runtime/MonoHelpers/MonoProvider.cs
+++ b/Runtime/MonoHelpers/MonoProvider.cs
@@ -1,7 +1,6 @@
 using UnityEngine;
 using Leopotam.EcsLite;
 using System.Collections.Generic;
-using ExitGames.Client.Photon.StructWrapping;
 
 namespace Voody.UniLeo.Lite
 {

--- a/Runtime/World/Systems/WorldInitSystem.cs
+++ b/Runtime/World/Systems/WorldInitSystem.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using Leopotam.EcsLite;
-using Unity.Mathematics;
 using UnityEngine;
 
 namespace Voody.UniLeo.Lite


### PR DESCRIPTION
- fix correct guid link to leoecs-lite assembly
- remove using ExitGames.Client.Photon.StructWrapping;
- remove using Unity.Mathematics;