### PR TITLE
Remove define Il2CppSetOptionAttribute

### DIFF
--- a/Runtime/World/Systems/WorldInitSystem.cs
+++ b/Runtime/World/Systems/WorldInitSystem.cs
@@ -87,21 +87,3 @@ namespace Voody.UniLeo.Lite
         }
     }
 }
-
-#if ENABLE_IL2CPP
-// Unity IL2CPP performance optimization attribute.
-namespace Unity.IL2CPP.CompilerServices {
-    enum Option {
-        NullChecks = 1,
-        ArrayBoundsChecks = 2
-    }
-
-    [AttributeUsage (AttributeTargets.Class | AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
-    class Il2CppSetOptionAttribute : Attribute {
-        public Option Option { get; private set; }
-        public object Value { get; private set; }
-
-        public Il2CppSetOptionAttribute (Option option, object value) { Option = option; Value = value; }
-    }
-}
-#endif


### PR DESCRIPTION
Inside the script worlds of LeoECS Lite has defined Il2CppSetOptionAttribute in the same namespace so redefining it will cause an error when building with IL2CPP